### PR TITLE
Add support for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Testcontainers module for [elasticsearch](https://www.elastic.co/products/elasticsearch).
 
-Note that it's based on the [official Docker image](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docker.html) provided by elastic.
+Note that it's based on the [official Docker image](https://www.elastic.co/guide/en/elasticsearch/reference/6.1/docker.html) provided by elastic.
 
 See [testcontainers.org](https://www.testcontainers.org) for more information about Testcontainers.
 
@@ -11,20 +11,31 @@ See [testcontainers.org](https://www.testcontainers.org) for more information ab
 You can start an elasticsearch container instance from any Java application by using:
 
 ```java
-// Specify the version you need
+// Specify the version you need.
 ElasticsearchContainer container = new ElasticsearchContainer()
-        .withVersion("5.6.3");
+        .withVersion("6.1.2");
 
-// You can also set what is the Docker registry you want to use with:
+// Optional: you can also set what is the Docker registry you want to use with.
 container.withBaseUrl("docker.elastic.co/elasticsearch/elasticsearch");
 
-// Configure the container (mandatory)
+// Optional: define which plugin you would like to install.
+// It will download it from internet when building the image
+container.withPlugin("discovery-gce");
+
+// Optional: define the plugins directory which should contain plugins ZIP files you want to install.
+// Note that if you want to just download an official plugin, use withPlugin(String) instead.
+container.withPluginDir(Paths.get("/path/to/zipped-plugins-dir"));
+
+// Optional: you can also change the password for X-Pack (for versions >= 6.1).
+container.withEnv("ELASTIC_PASSWORD", "changeme");
+
+// Configure the container (mandatory).
 container.configure();
 
-// Start the container
+// Start the container.
 container.start();
 
-// Do whatever you want here
+// Do whatever you want here.
 final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
 credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("elastic", "changeme"));
 RestClient client = RestClient.builder(container.getHost())
@@ -32,11 +43,11 @@ RestClient client = RestClient.builder(container.getHost())
         .build();
 Response response = client.performRequest("GET", "/");
 
-// Stop the container
+// Stop the container.
 container.stop();
 ```
 
-## JUnit Usage example
+## JUnit 4 Usage example
 
 Running elasticsearch as a resource during a test:
 
@@ -64,7 +75,7 @@ the settings will be read from it:
 
 ```properties
 baseUrl=docker.elastic.co/elasticsearch/elasticsearch
-version=6.0.0-rc1
+version=6.1.2
 ```
 
 You can also define this programmatically with:
@@ -73,7 +84,9 @@ You can also define this programmatically with:
 @Rule
 public ElasticsearchResource elasticsearch = new ElasticsearchResource(
     "docker.elastic.co/elasticsearch/elasticsearch", // baseUrl (can be null)
-    "6.0.0-rc1");                                    // version
+    "6.1.2",                                         // version
+    Paths.get("/path/to/zipped-plugins-dir"),        // pluginsDir (can be null)
+    "changeme");                                     // X-Pack security password to set (can be null)
 ```
 
 ## Dependency information
@@ -101,5 +114,5 @@ See [LICENSE](LICENSE).
 
 ## Copyright
 
-Copyright (c) 2017 David Pilato.
+Copyright (c) 2017, 2018 David Pilato.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-parent</artifactId>
-        <version>1.4.3</version>
+        <version>1.5.1</version>
     </parent>
 
     <groupId>fr.pilato.elasticsearch.testcontainers</groupId>
@@ -25,8 +25,15 @@
     </licenses>
 
     <properties>
-        <elasticsearch.client.version>6.0.0-rc1</elasticsearch.client.version>
+        <!-- WARN: anytime you change the version, change profiles copy-plugin and fake-elastic-maven-repository -->
+        <elasticsearch.version>6.1.2</elasticsearch.version>
+        <!-- WARN: anytime you change the version, change profiles copy-old-plugin and fake-elastic-maven-repository-for-old-plugin -->
+        <elasticsearch.version.old>5.6.3</elasticsearch.version.old>
+        <elasticsearch.client.version>${elasticsearch.version}</elasticsearch.client.version>
         <integ.http.port>9400</integ.http.port>
+        <plugin.dir>${project.build.directory}/plugins</plugin.dir>
+        <xpack.password>changeme</xpack.password>
+        <skipTests>false</skipTests>
     </properties>
 
     <dependencies>
@@ -40,6 +47,14 @@
             <artifactId>elasticsearch-rest-client</artifactId>
             <version>${elasticsearch.client.version}</version>
         </dependency>
+        <dependency>
+            <!-- TODO remove when https://github.com/testcontainers/testcontainers-java/pull/559 is merged -->
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <!-- Needed when using Java9 -->
+            <version>1.16.20</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -49,7 +64,22 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -70,7 +100,221 @@
         <url>https://github.com/dadoonet/testcontainers-java-module-elasticsearch</url>
     </scm>
 
+    <repositories>
+        <!-- This repository is used to test with x-pack -->
+        <repository>
+            <id>elastic-download-service</id>
+            <name>Elastic Download Service</name>
+            <url>https://artifacts.elastic.co/maven/</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+
+        <repository>
+            <id>oss-snapshots</id>
+            <name>Sonatype OSS Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <releases><enabled>false</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+    </repositories>
+
     <profiles>
+        <profile>
+            <id>fake-elastic-maven-repository</id>
+            <activation>
+                <file>
+                    <!-- WARN: change this if you change the the elasticsearch.version -->
+                    <missing>${user.home}/.m2/repository/org/elasticsearch/plugin/ingest-attachment/6.1.2/ingest-attachment-6.1.2.zip</missing>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Annoying we need to fake elastic maven repository -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>wagon-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <id>download-ingest-attachment</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>download-single</goal>
+                                </goals>
+                                <configuration>
+                                    <url>https://artifacts.elastic.co</url>
+                                    <fromFile>downloads/elasticsearch-plugins/ingest-attachment/ingest-attachment-${elasticsearch.version}.zip</fromFile>
+                                    <toDir>${plugin.dir}/${elasticsearch.version}</toDir>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <version>2.5.2</version>
+                        <executions>
+                            <execution>
+                                <id>fake-elasticsearch-repository</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>install-file</goal>
+                                </goals>
+                                <configuration>
+                                    <file>${plugin.dir}/${elasticsearch.version}/ingest-attachment-${elasticsearch.version}.zip</file>
+                                    <groupId>org.elasticsearch.plugin</groupId>
+                                    <artifactId>ingest-attachment</artifactId>
+                                    <version>${elasticsearch.version}</version>
+                                    <packaging>zip</packaging>
+                                    <generatePom>true</generatePom>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>fake-elastic-maven-repository-for-old-plugin</id>
+            <activation>
+                <file>
+                    <!-- WARN: change this if you change the the elasticsearch.version.old -->
+                    <missing>${user.home}/.m2/repository/org/elasticsearch/plugin/ingest-attachment/5.6.3/ingest-attachment-5.6.3.zip</missing>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Annoying we need to fake elastic maven repository -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>wagon-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <id>download-ingest-attachment-old</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>download-single</goal>
+                                </goals>
+                                <configuration>
+                                    <url>https://artifacts.elastic.co</url>
+                                    <fromFile>downloads/elasticsearch-plugins/ingest-attachment/ingest-attachment-${elasticsearch.version.old}.zip</fromFile>
+                                    <toDir>${plugin.dir}/${elasticsearch.version.old}</toDir>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <version>2.5.2</version>
+                        <executions>
+                            <execution>
+                                <id>fake-elasticsearch-repository-old</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>install-file</goal>
+                                </goals>
+                                <configuration>
+                                    <file>${plugin.dir}/${elasticsearch.version.old}/ingest-attachment-${elasticsearch.version.old}.zip</file>
+                                    <groupId>org.elasticsearch.plugin</groupId>
+                                    <artifactId>ingest-attachment</artifactId>
+                                    <version>${elasticsearch.version.old}</version>
+                                    <packaging>zip</packaging>
+                                    <generatePom>true</generatePom>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>copy-plugin</id>
+            <activation>
+                <file>
+                    <!-- WARN: change this if you change the the elasticsearch.version -->
+                    <missing>target/plugins/6.1.2/ingest-attachment-6.1.2.zip</missing>
+                </file>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Copy some plugins for integration testing -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>2.10</version>
+                        <executions>
+                            <execution>
+                                <id>integ-setup-dependencies-plugins</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.elasticsearch.plugin</groupId>
+                                            <artifactId>ingest-attachment</artifactId>
+                                            <version>${elasticsearch.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <useBaseVersion>true</useBaseVersion>
+                                    <outputDirectory>${plugin.dir}/${elasticsearch.version}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>copy-old-plugin</id>
+            <activation>
+                <file>
+                    <!-- WARN: change this if you change the the elasticsearch.version.old -->
+                    <missing>target/plugins/5.6.3/ingest-attachment-5.6.3.zip</missing>
+                </file>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Copy some plugins for integration testing -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>2.10</version>
+                        <executions>
+                            <execution>
+                                <id>integ-setup-dependencies-plugins-old</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.elasticsearch.plugin</groupId>
+                                            <artifactId>ingest-attachment</artifactId>
+                                            <version>${elasticsearch.version.old}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <useBaseVersion>true</useBaseVersion>
+                                    <outputDirectory>${plugin.dir}/${elasticsearch.version.old}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>release</id>
             <build>

--- a/src/main/java/fr/pilato/elasticsearch/containers/ElasticsearchResource.java
+++ b/src/main/java/fr/pilato/elasticsearch/containers/ElasticsearchResource.java
@@ -26,6 +26,11 @@ import org.rnorth.ducttape.Preconditions;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import static fr.pilato.elasticsearch.containers.ElasticsearchContainer.ELASTICSEARCH_DEFAULT_BASE_URL;
@@ -39,6 +44,9 @@ public class ElasticsearchResource extends ExternalResource {
     private static final String FALLBACK_RESOURCE_NAME = "elasticsearch-default.properties";
     private final String baseUrl;
     private final String version;
+    private final Path pluginDir;
+    private final String password;
+    private final List<String> plugins;
     @Nullable private ElasticsearchContainer delegate;
 
     public ElasticsearchResource() {
@@ -49,23 +57,38 @@ public class ElasticsearchResource extends ExternalResource {
      * Generate a resource programmatically
      * @param baseUrl   If null defaults to ELASTICSEARCH_DEFAULT_BASE_URL
      * @param version   Elasticsearch version to start
+     * @param pluginDir Plugin dir which might contain plugins to install. Can be null.
+     * @param plugins   Plugins to install. Can be null.
+     * @param password  X-Pack default password. Can be null.
      */
-    public ElasticsearchResource(String baseUrl, String version) {
+    public ElasticsearchResource(String baseUrl, String version, Path pluginDir, List<String> plugins, String password) {
         this.baseUrl = baseUrl == null ? ELASTICSEARCH_DEFAULT_BASE_URL : baseUrl;
         this.version = version;
+        this.pluginDir = pluginDir;
+        this.plugins = plugins;
+        this.password = password;
     }
 
     public ElasticsearchResource(String resourceName) {
         // Find the latest version this project was built with
         String propVersion;
         String propBaseUrl;
+        String propPlugins;
+        String propPluginDir;
+        String propPassword;
         String defaultBaseUrl = null;
         String defaultVersion = null;
+        String defaultPlugins = null;
+        String defaultPluginDir = null;
+        String defaultPassword = null;
         Properties props = new Properties();
         try {
             props.load(ElasticsearchResource.class.getResourceAsStream(FALLBACK_RESOURCE_NAME));
             defaultBaseUrl = props.getProperty("baseUrl");
             defaultVersion = props.getProperty("version");
+            defaultPlugins = props.getProperty("plugins");
+            defaultPluginDir = props.getProperty("pluginDir");
+            defaultPassword = props.getProperty("password");
         } catch (IOException ignored) {
             // This can normally never happen unless someone modifies the JAR file o_O
         }
@@ -75,26 +98,57 @@ public class ElasticsearchResource extends ExternalResource {
                 props.load(stream);
                 propBaseUrl = props.getProperty("baseUrl", defaultBaseUrl);
                 propVersion = props.getProperty("version", defaultVersion);
+                propPlugins = props.getProperty("plugins", defaultPluginDir);
+                propPluginDir = props.getProperty("pluginDir", defaultPluginDir);
+                propPassword = props.getProperty("password", defaultPassword);
             } else {
                 propBaseUrl = defaultBaseUrl;
                 propVersion = defaultVersion;
+                propPlugins = defaultPlugins;
+                propPluginDir = defaultPluginDir;
+                propPassword = defaultPassword;
             }
         } catch (IOException e) {
             // We might get that exception if the user provides a badly formatted property file
             propBaseUrl = null;
             propVersion = null;
+            propPlugins = null;
+            propPluginDir = null;
+            propPassword = null;
         }
         baseUrl = propBaseUrl;
         version = propVersion;
+        plugins = generateFromCommaSeparatedString(propPlugins);
+        pluginDir = propPluginDir == null ? null : Paths.get(propPluginDir);
+        password = propPassword;
+    }
+
+    private List<String> generateFromCommaSeparatedString(String value) {
+        List<String> values = new ArrayList<>();
+        if (value != null) {
+            values.addAll(Arrays.asList(value.split(",")));
+        }
+
+        return values;
     }
 
     @Override
-    protected void before() throws Throwable {
+    protected void before() {
         Preconditions.check("baseUrl can't be null", baseUrl != null);
         Preconditions.check("version can't be null", version != null);
         delegate = new ElasticsearchContainer()
                 .withBaseUrl(baseUrl)
-                .withVersion(version);
+                .withVersion(version)
+                .withPluginDir(pluginDir);
+
+        for (String plugin : plugins) {
+            delegate = delegate.withPlugin(plugin);
+        }
+
+        if (password != null && !password.isEmpty()) {
+            delegate.withEnv("ELASTIC_PASSWORD", password);
+        }
+
         delegate.start();
     }
 
@@ -111,5 +165,14 @@ public class ElasticsearchResource extends ExternalResource {
     public HttpHost getHost() {
         Preconditions.check("delegate must have been created by before()", delegate != null);
         return delegate.getHost();
+    }
+
+    @Nullable
+    public ElasticsearchContainer getContainer() {
+        return delegate;
+    }
+
+    public String getPassword() {
+        return password;
     }
 }

--- a/src/main/resources/fr/pilato/elasticsearch/containers/elasticsearch-default.properties
+++ b/src/main/resources/fr/pilato/elasticsearch/containers/elasticsearch-default.properties
@@ -1,2 +1,3 @@
 baseUrl=docker.elastic.co/elasticsearch/elasticsearch
-version=${elasticsearch.client.version}
+version=${elasticsearch.version}
+password=${xpack.password}

--- a/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceDefaultsTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceDefaultsTest.java
@@ -20,25 +20,14 @@
 package fr.pilato.elasticsearch.containers;
 
 
-import org.junit.Rule;
-
-import java.io.IOException;
-
-import static org.junit.Assume.assumeTrue;
+import org.junit.ClassRule;
 
 public class ElasticsearchResourceDefaultsTest extends ElasticsearchResourceBaseTest {
-    @Rule
-    public ElasticsearchResource elasticsearch = new ElasticsearchResource();
+    @ClassRule
+    public static ElasticsearchResource elasticsearch = new ElasticsearchResource();
 
     @Override
     ElasticsearchResource getElasticsearchResource() {
         return elasticsearch;
-    }
-
-    @Override
-    public void elasticsearchTest() throws IOException {
-        // Let's just ignore this test because with elasticsearch 6.0.0-rc1, we don't have a default
-        // User/Password anymore
-        assumeTrue("We skip the test with elasticsearch 6.0.0-rc1 for now", false);
     }
 }

--- a/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceWithPluginsAndPluginsDirTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceWithPluginsAndPluginsDirTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.containers;
+
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Response;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Note that this class requires internet to run as it will try to download an elasticsearch plugin
+ */
+public class ElasticsearchResourceWithPluginsAndPluginsDirTest extends ElasticsearchResourceBaseTest {
+
+    @ClassRule
+    public static ElasticsearchResource elasticsearch = new ElasticsearchResource("elasticsearch-plugins-and-plugins-dir.properties");
+
+    @Override
+    ElasticsearchResource getElasticsearchResource() {
+        return elasticsearch;
+    }
+
+    @Test
+    public void testPluginsAreInstalled() {
+        String list = executeCommandInDocker("bin/elasticsearch-plugin", "list");
+        assertThat(list, containsString("ingest-attachment"));
+        assertThat(list, containsString("discovery-gce"));
+    }
+
+    @Test
+    public void testPluginsAreLoaded() throws IOException {
+        Response response = restClient.performRequest("GET", "/_cat/plugins");
+        assertThat(response.getStatusLine().getStatusCode(), is(200));
+        String responseAsString = EntityUtils.toString(response.getEntity());
+        assertThat(responseAsString, containsString("ingest-attachment"));
+        assertThat(responseAsString, containsString("discovery-gce"));
+    }
+
+    private String executeCommandInDocker(String... params) {
+        try {
+            return elasticsearch.getContainer().execInContainer(params).getStdout();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceWithPluginsDirTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceWithPluginsDirTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.containers;
+
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Response;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ElasticsearchResourceWithPluginsDirTest extends ElasticsearchResourceBaseTest {
+    @ClassRule
+    public static ElasticsearchResource elasticsearch = new ElasticsearchResource("elasticsearch-plugins-dir-version.properties");
+
+    @Override
+    ElasticsearchResource getElasticsearchResource() {
+        return elasticsearch;
+    }
+
+    @Test
+    public void testPluginsAreInstalled() {
+        String list = executeCommandInDocker("bin/elasticsearch-plugin", "list");
+        assertThat(list, containsString("ingest-attachment"));
+    }
+
+    @Test
+    public void testPluginsAreLoaded() throws IOException {
+        Response response = restClient.performRequest("GET", "/_cat/plugins");
+        assertThat(response.getStatusLine().getStatusCode(), is(200));
+        String responseAsString = EntityUtils.toString(response.getEntity());
+        assertThat(responseAsString, containsString("ingest-attachment"));
+    }
+
+    private String executeCommandInDocker(String... params) {
+        try {
+            return elasticsearch.getContainer().execInContainer(params).getStdout();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceWithPluginsTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceWithPluginsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.containers;
+
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Response;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Note that this class requires internet to run as it will try to download an elasticsearch plugin
+ */
+public class ElasticsearchResourceWithPluginsTest extends ElasticsearchResourceBaseTest {
+    @ClassRule
+    public static ElasticsearchResource elasticsearch = new ElasticsearchResource("elasticsearch-plugins.properties");
+
+    @Override
+    ElasticsearchResource getElasticsearchResource() {
+        return elasticsearch;
+    }
+
+    @Test
+    public void testPluginsAreInstalled() {
+        String list = executeCommandInDocker("bin/elasticsearch-plugin", "list");
+        assertThat(list, containsString("ingest-attachment"));
+        assertThat(list, containsString("discovery-gce"));
+    }
+
+    @Test
+    public void testPluginsAreLoaded() throws IOException {
+        Response response = restClient.performRequest("GET", "/_cat/plugins");
+        assertThat(response.getStatusLine().getStatusCode(), is(200));
+        String responseAsString = EntityUtils.toString(response.getEntity());
+        assertThat(responseAsString, containsString("ingest-attachment"));
+        assertThat(responseAsString, containsString("discovery-gce"));
+    }
+
+    private String executeCommandInDocker(String... params) {
+        try {
+            return elasticsearch.getContainer().execInContainer(params).getStdout();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceWithVersionTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceWithVersionTest.java
@@ -20,11 +20,11 @@
 package fr.pilato.elasticsearch.containers;
 
 
-import org.junit.Rule;
+import org.junit.ClassRule;
 
 public class ElasticsearchResourceWithVersionTest extends ElasticsearchResourceBaseTest {
-    @Rule
-    public ElasticsearchResource elasticsearch = new ElasticsearchResource("elasticsearch-version.properties");
+    @ClassRule
+    public static ElasticsearchResource elasticsearch = new ElasticsearchResource("elasticsearch-version.properties");
 
     @Override
     ElasticsearchResource getElasticsearchResource() {

--- a/src/test/resources/fr/pilato/elasticsearch/containers/elasticsearch-plugins-and-plugins-dir.properties
+++ b/src/test/resources/fr/pilato/elasticsearch/containers/elasticsearch-plugins-and-plugins-dir.properties
@@ -1,0 +1,2 @@
+plugins=discovery-gce
+pluginDir=${plugin.dir}/${elasticsearch.version}

--- a/src/test/resources/fr/pilato/elasticsearch/containers/elasticsearch-plugins-dir-version.properties
+++ b/src/test/resources/fr/pilato/elasticsearch/containers/elasticsearch-plugins-dir-version.properties
@@ -1,0 +1,2 @@
+version=${elasticsearch.version.old}
+pluginDir=${plugin.dir}/${elasticsearch.version.old}

--- a/src/test/resources/fr/pilato/elasticsearch/containers/elasticsearch-plugins-dir.properties
+++ b/src/test/resources/fr/pilato/elasticsearch/containers/elasticsearch-plugins-dir.properties
@@ -1,0 +1,1 @@
+pluginDir=${plugin.dir}/${elasticsearch.version}

--- a/src/test/resources/fr/pilato/elasticsearch/containers/elasticsearch-plugins.properties
+++ b/src/test/resources/fr/pilato/elasticsearch/containers/elasticsearch-plugins.properties
@@ -1,0 +1,1 @@
+plugins=ingest-attachment,discovery-gce

--- a/src/test/resources/fr/pilato/elasticsearch/containers/elasticsearch-version.properties
+++ b/src/test/resources/fr/pilato/elasticsearch/containers/elasticsearch-version.properties
@@ -1,1 +1,1 @@
-version=5.6.3
+version=${elasticsearch.version.old}


### PR DESCRIPTION
* Update to testcontainers 1.5.1 (See #3)
* Add support for X-Pack password and update ES to 6.1.2 (See #1)
* Upgrade Lombok for Java9 support See https://github.com/testcontainers/testcontainers-java/pull/559
* Add some docs about plugins
* Fix NPE when version is not set
* Add more Java based tests using directly the `ElasticsearchContainer` class.
* Add ingest-attachment for 6.1.2
* Also move non prod code to test (`executeCommandInDocker`)
* Add support for "standard" plugins
* Be specific about JUnit 4
* Remove Deprecated and fix Warnings

Closes #1.
Closes #3.