### PR TITLE
Don't call `super.getLivenessCheckPorts()`

### DIFF
--- a/src/main/java/fr/pilato/elasticsearch/containers/ElasticsearchContainer.java
+++ b/src/main/java/fr/pilato/elasticsearch/containers/ElasticsearchContainer.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -145,9 +146,7 @@ public class ElasticsearchContainer<SELF extends ElasticsearchContainer<SELF>> e
     @NotNull
     @Override
     protected Set<Integer> getLivenessCheckPorts() {
-        Set<Integer> ports = new HashSet<>(super.getLivenessCheckPorts());
-        ports.add(getMappedPort(ELASTICSEARCH_DEFAULT_PORT));
-        return ports;
+        return ImmutableSet.of(getMappedPort(ELASTICSEARCH_DEFAULT_PORT));
     }
 
     @Override


### PR DESCRIPTION
As reported in https://github.com/dadoonet/testcontainers-java-module-elasticsearch/issues/27#issuecomment-389418625,

we don't need to call `super.getLivenessCheckPorts()` in:

```java
protected Set<Integer> getLivenessCheckPorts() {
        Set<Integer> ports = new HashSet<>(super.getLivenessCheckPorts());
        ports.add(getMappedPort(ELASTICSEARCH_DEFAULT_PORT));
        return ports;
}
```

So we can simplify the code with:

```java
protected Set<Integer> getLivenessCheckPorts() {
  return ImmutableSet.of(getMappedPort(ELASTICSEARCH_DEFAULT_PORT));
}
```

Closes #27.