### PR TITLE
Update to testcontainers 1.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers-parent</artifactId>
-        <version>1.6.0</version>
-    </parent>
 
     <groupId>fr.pilato.elasticsearch.testcontainers</groupId>
     <artifactId>testcontainers-elasticsearch</artifactId>
@@ -23,6 +18,7 @@
     </licenses>
 
     <properties>
+        <testcontainer.version>1.6.0</testcontainer.version>
         <!-- WARN: anytime you change the version, change profiles copy-plugin and fake-elastic-maven-repository -->
         <elasticsearch.version>6.3.0</elasticsearch.version>
         <!-- WARN: anytime you change the version, change profiles copy-old-plugin and fake-elastic-maven-repository-for-old-plugin -->
@@ -32,6 +28,9 @@
         <plugin.dir>${project.build.directory}/plugins</plugin.dir>
         <xpack.password>changeme</xpack.password>
         <skipTests>false</skipTests>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <issueManagement>
@@ -53,12 +52,19 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${testcontainer.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
             <version>${elasticsearch.client.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </licenses>
 
     <properties>
-        <testcontainer.version>1.6.0</testcontainer.version>
+        <testcontainer.version>1.7.0</testcontainer.version>
         <!-- WARN: anytime you change the version, change profiles copy-plugin and fake-elastic-maven-repository -->
         <elasticsearch.version>6.3.0</elasticsearch.version>
         <!-- WARN: anytime you change the version, change profiles copy-old-plugin and fake-elastic-maven-repository-for-old-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </licenses>
 
     <properties>
-        <testcontainer.version>1.7.0</testcontainer.version>
+        <testcontainer.version>1.8.2</testcontainer.version>
         <!-- WARN: anytime you change the version, change profiles copy-plugin and fake-elastic-maven-repository -->
         <elasticsearch.version>6.3.0</elasticsearch.version>
         <!-- WARN: anytime you change the version, change profiles copy-old-plugin and fake-elastic-maven-repository-for-old-plugin -->

--- a/src/main/java/fr/pilato/elasticsearch/containers/ElasticsearchContainer.java
+++ b/src/main/java/fr/pilato/elasticsearch/containers/ElasticsearchContainer.java
@@ -20,7 +20,6 @@
 package fr.pilato.elasticsearch.containers;
 
 import org.apache.http.HttpHost;
-import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
@@ -31,7 +30,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -143,9 +141,8 @@ public class ElasticsearchContainer<SELF extends ElasticsearchContainer<SELF>> e
         return this;
     }
 
-    @NotNull
     @Override
-    protected Set<Integer> getLivenessCheckPorts() {
+    public Set<Integer> getLivenessCheckPortNumbers() {
         return ImmutableSet.of(getMappedPort(ELASTICSEARCH_DEFAULT_PORT));
     }
 

--- a/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceContructorTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/containers/ElasticsearchResourceContructorTest.java
@@ -35,7 +35,7 @@ public class ElasticsearchResourceContructorTest {
     // We don't annotate it as a Rule as we just want to have it here for documentation
     public ElasticsearchResource elasticsearch = new ElasticsearchResource(
             "docker.elastic.co/elasticsearch/elasticsearch", // baseUrl (can be null)
-            "6.2.1",                                         // version (can be null)
+            "6.3.0",                                         // version (can be null)
             Paths.get("/path/to/zipped-plugins-dir"),        // pluginsDir (can be null)
             Collections.singletonList("ingest-attachment"),  // standard plugins (can be empty)
             Collections.singletonMap("foo", "bar"),          // Map of secured settings (can be empty)

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -12,10 +12,12 @@
         <appender-ref ref="STDOUT"/>
     </root>
 
+    <logger name="fr.pilato" level="INFO"/>
     <logger name="org.apache.http" level="WARN"/>
     <logger name="com.github.dockerjava" level="WARN"/>
     <logger name="org.zeroturnaround.exec" level="WARN"/>
     <logger name="io.netty" level="WARN" />
+    <logger name="org.testcontainers" level="WARN"/>
     <logger name="org.testcontainers.shaded" level="WARN"/>
 
     <!-- Prevent noisy logs - any errors thrown will be logged when caught if they need to be -->


### PR DESCRIPTION
This has multiple steps.

* We start to remove the dependency to the parent pom as the parent project is moving to Gradle.
* We update to 1.8.2
